### PR TITLE
Support I18n 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- Support i18n 1.10.0
+- Drop support for Ruby < 2.7
+
 ## v1.1.0
 
 - Remove upper bound on i18n dependency

--- a/i18n-backend-side_by_side.gemspec
+++ b/i18n-backend-side_by_side.gemspec
@@ -16,9 +16,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
-  spec.add_dependency 'i18n', '>= 1.3.0'
+  spec.add_dependency 'i18n', '>= 1.10.0'
+  spec.add_dependency 'activesupport', '>= 6.0.0'
 end

--- a/lib/i18n/backend/side_by_side.rb
+++ b/lib/i18n/backend/side_by_side.rb
@@ -1,10 +1,8 @@
 require 'i18n'
-require 'i18n/core_ext/hash'
+require 'active_support/core_ext/hash/keys'
 
 module I18n
   module Backend
-    using HashRefinements
-
     class SideBySide < Simple
       VERSION = File.read(File.expand_path('../../../../VERSION', __FILE__))
       LOCALE_PREFIX = '_'
@@ -14,13 +12,13 @@ module I18n
       def load_file(filename)
         type = File.extname(filename).tr('.', '').downcase
         raise UnknownFileType.new(type, filename) unless respond_to?(:"load_#{type}", true)
-        data = send(:"load_#{type}", filename)
+        data = send(:"load_#{type}", filename).first
         unless data.is_a?(Hash)
           raise InvalidLocaleData.new(filename, 'expects it to return a hash, but does not')
         end
 
-        if data.first.first == LOCALE_PREFIX
-          _process([], data[LOCALE_PREFIX].deep_symbolize_keys)
+        if data.first.first.to_s == LOCALE_PREFIX
+          _process([], data.deep_symbolize_keys[LOCALE_PREFIX.to_sym])
         else
           data.each { |locale, d| store_translations(locale, d || {}) }
         end


### PR DESCRIPTION
This upgrades the logic to support the I18n 1.10.0 release, that was
broking with issue like:

```
LoadError: cannot load such file -- i18n/core_ext/hash
```

or
```
NameError: uninitialized constant I18n::HashRefinements
```

The I18n internal hash structure also changed sightly, so this fix
accomodates that.

Deprecated Ruby versions (< 2.7) are also removed for good measure.

Related I18n issue:
- https://github.com/ruby-i18n/i18n/pull/602